### PR TITLE
docs: fixed the license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ bundle exec sass --update --force --style compressed _sass/leap.sass:css/leap.mi
 ```
 
 ## Copyright and license
-Code and documentation copyright 2021 Treehouse Island, Inc. Code released under the [MIT license](https://github.com/treehouse/project-leap/LICENSE).
+Code and documentation copyright 2021 Treehouse Island, Inc. Code released under the [MIT license](https://github.com/treehouse/project-leap/blob/main/LICENSE).


### PR DESCRIPTION
fixed the license link, the old one didn't work